### PR TITLE
Upstream: Updates LibSass to v3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 libsass-net
 ===========
 
+[![AppVeyor CI Status](https://ci.appveyor.com/api/projects/status/github/darrenkopp/libsass-net?svg=true)](https://ci.appveyor.com/project/darrenkopp/libsass-net/branch/master)
+
 A lightweight wrapper around libsass
 
 Requires [Visual C++ Redistributable](http://www.microsoft.com/en-us/download/details.aspx?id=40784)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,13 @@
+configuration:
+  - Debug
+  - Release
+
+install:
+  - git submodule update --init --recursive
+
+before_build:
+  - nuget restore
+
+build:
+  verbosity: minimal
+  project: libsass-net.sln

--- a/libsass/LibSass.vcxproj
+++ b/libsass/LibSass.vcxproj
@@ -24,33 +24,102 @@
     <ClCompile Include="native\ast.cpp" />
     <ClCompile Include="native\base64vlq.cpp" />
     <ClCompile Include="native\bind.cpp" />
-    <ClCompile Include="native\constants.cpp" />
-    <ClCompile Include="native\context.cpp" />
-    <ClCompile Include="native\contextualize.cpp" />
-    <ClCompile Include="native\copy_c_str.cpp" />
-    <ClCompile Include="native\error_handling.cpp" />
-    <ClCompile Include="native\eval.cpp" />
-    <ClCompile Include="native\expand.cpp" />
-    <ClCompile Include="native\extend.cpp" />
-    <ClCompile Include="native\file.cpp" />
-    <ClCompile Include="native\functions.cpp" />
-    <ClCompile Include="native\inspect.cpp" />
-    <ClCompile Include="native\node.cpp" />
-    <ClCompile Include="native\output_compressed.cpp" />
-    <ClCompile Include="native\output_nested.cpp" />
-    <ClCompile Include="native\parser.cpp" />
-    <ClCompile Include="native\prelexer.cpp" />
-    <ClCompile Include="native\remove_placeholders.cpp" />
-    <ClCompile Include="native\sass.cpp" />
-    <ClCompile Include="native\sass2scss.cpp" />
-    <ClCompile Include="native\sass_interface.cpp" />
-    <ClCompile Include="native\sass_util.cpp" />
-    <ClCompile Include="native\source_map.cpp" />
-    <ClCompile Include="native\to_c.cpp" />
-    <ClCompile Include="native\to_string.cpp" />
-    <ClCompile Include="native\units.cpp" />
-    <ClCompile Include="native\utf8_string.cpp" />
-    <ClCompile Include="native\util.cpp" />
+    <ClCompile Include="native\cencode.c">
+      <CompileAsManaged>false</CompileAsManaged>
+    </ClCompile>
+    <ClCompile Include="native\constants.cpp">
+      <CompileAsManaged>false</CompileAsManaged>
+    </ClCompile>
+    <ClCompile Include="native\context.cpp">
+      <CompileAsManaged>false</CompileAsManaged>
+    </ClCompile>
+    <ClCompile Include="native\contextualize.cpp">
+      <CompileAsManaged>false</CompileAsManaged>
+    </ClCompile>
+    <ClCompile Include="native\copy_c_str.cpp">
+      <CompileAsManaged>false</CompileAsManaged>
+    </ClCompile>
+    <ClCompile Include="native\error_handling.cpp">
+      <CompileAsManaged>false</CompileAsManaged>
+    </ClCompile>
+    <ClCompile Include="native\eval.cpp">
+      <CompileAsManaged>false</CompileAsManaged>
+    </ClCompile>
+    <ClCompile Include="native\expand.cpp">
+      <CompileAsManaged>false</CompileAsManaged>
+    </ClCompile>
+    <ClCompile Include="native\extend.cpp">
+      <CompileAsManaged>false</CompileAsManaged>
+    </ClCompile>
+    <ClCompile Include="native\file.cpp">
+      <CompileAsManaged>false</CompileAsManaged>
+    </ClCompile>
+    <ClCompile Include="native\functions.cpp">
+      <CompileAsManaged>false</CompileAsManaged>
+    </ClCompile>
+    <ClCompile Include="native\inspect.cpp">
+      <CompileAsManaged>false</CompileAsManaged>
+    </ClCompile>
+    <ClCompile Include="native\json.cpp">
+      <CompileAsManaged>false</CompileAsManaged>
+    </ClCompile>
+    <ClCompile Include="native\node.cpp">
+      <CompileAsManaged>false</CompileAsManaged>
+    </ClCompile>
+    <ClCompile Include="native\output_compressed.cpp">
+      <CompileAsManaged>false</CompileAsManaged>
+    </ClCompile>
+    <ClCompile Include="native\output_nested.cpp">
+      <CompileAsManaged>false</CompileAsManaged>
+    </ClCompile>
+    <ClCompile Include="native\parser.cpp">
+      <CompileAsManaged>false</CompileAsManaged>
+    </ClCompile>
+    <ClCompile Include="native\prelexer.cpp">
+      <CompileAsManaged>false</CompileAsManaged>
+    </ClCompile>
+    <ClCompile Include="native\remove_placeholders.cpp">
+      <CompileAsManaged>false</CompileAsManaged>
+    </ClCompile>
+    <ClCompile Include="native\sass.cpp">
+      <CompileAsManaged>false</CompileAsManaged>
+    </ClCompile>
+    <ClCompile Include="native\sass2scss.cpp">
+      <CompileAsManaged>false</CompileAsManaged>
+    </ClCompile>
+    <ClCompile Include="native\sass_interface.cpp">
+      <CompileAsManaged>false</CompileAsManaged>
+    </ClCompile>
+    <ClCompile Include="native\sass_context.cpp">
+      <CompileAsManaged>false</CompileAsManaged>
+    </ClCompile>
+    <ClCompile Include="native\sass_functions.cpp">
+      <CompileAsManaged>false</CompileAsManaged>
+    </ClCompile>
+    <ClCompile Include="native\sass_values.cpp">
+      <CompileAsManaged>false</CompileAsManaged>
+    </ClCompile>
+    <ClCompile Include="native\sass_util.cpp">
+      <CompileAsManaged>false</CompileAsManaged>
+    </ClCompile>
+    <ClCompile Include="native\source_map.cpp">
+      <CompileAsManaged>false</CompileAsManaged>
+    </ClCompile>
+    <ClCompile Include="native\to_c.cpp">
+      <CompileAsManaged>false</CompileAsManaged>
+    </ClCompile>
+    <ClCompile Include="native\to_string.cpp">
+      <CompileAsManaged>false</CompileAsManaged>
+    </ClCompile>
+    <ClCompile Include="native\units.cpp">
+      <CompileAsManaged>false</CompileAsManaged>
+    </ClCompile>
+    <ClCompile Include="native\utf8_string.cpp">
+      <CompileAsManaged>false</CompileAsManaged>
+    </ClCompile>
+    <ClCompile Include="native\util.cpp">
+      <CompileAsManaged>false</CompileAsManaged>
+    </ClCompile>
     <ClCompile Include="SassInterface.cpp" />
     <ClCompile Include="StringToANSI.cpp" />
   </ItemGroup>
@@ -70,6 +139,7 @@
     <ClInclude Include="native\context.hpp" />
     <ClInclude Include="native\contextualize.hpp" />
     <ClInclude Include="native\copy_c_str.hpp" />
+    <ClInclude Include="native\debug.hpp" />
     <ClInclude Include="native\environment.hpp" />
     <ClInclude Include="native\error_handling.hpp" />
     <ClInclude Include="native\eval.hpp" />
@@ -78,6 +148,7 @@
     <ClInclude Include="native\file.hpp" />
     <ClInclude Include="native\functions.hpp" />
     <ClInclude Include="native\inspect.hpp" />
+    <ClInclude Include="native\json.hpp" />
     <ClInclude Include="native\kwd_arg_macros.hpp" />
     <ClInclude Include="native\mapping.hpp" />
     <ClInclude Include="native\memory_manager.hpp" />
@@ -92,7 +163,10 @@
     <ClInclude Include="native\remove_placeholders.hpp" />
     <ClInclude Include="native\sass.h" />
     <ClInclude Include="native\sass2scss.h" />
+    <ClInclude Include="native\sass_context.h" />
+    <ClInclude Include="native\sass_functions.h" />
     <ClInclude Include="native\sass_interface.h" />
+    <ClInclude Include="native\sass_values.h" />
     <ClInclude Include="native\sass_util.hpp" />
     <ClInclude Include="native\source_map.hpp" />
     <ClInclude Include="native\subset_map.hpp" />
@@ -101,6 +175,9 @@
     <ClInclude Include="native\to_string.hpp" />
     <ClInclude Include="native\units.hpp" />
     <ClInclude Include="native\utf8.h" />
+    <ClInclude Include="native\utf8\checked.h" />
+    <ClInclude Include="native\utf8\core.h" />
+    <ClInclude Include="native\utf8\unchecked.h" />
     <ClInclude Include="native\utf8_string.hpp" />
     <ClInclude Include="native\util.hpp" />
     <ClInclude Include="SassInterface.hpp" />

--- a/libsass/SassInterface.cpp
+++ b/libsass/SassInterface.cpp
@@ -20,6 +20,7 @@
 
 #include <exception>
 #include "native\sass_interface.h"
+#include "native\sass2scss.h"
 #include "StringToANSI.hpp"
 #include "SassInterface.hpp"
 
@@ -124,7 +125,7 @@ namespace LibSassNet
 		{
 			sourceText = MarshalString(context->SourceText);
 
-			char* result = Sass::sass2scss(sourceText, 128);
+			char* result = sass2scss(sourceText, 128);
 			context->OutputText = gcnew String(result);
 
 			FreeString(result);

--- a/libsassnet.Web/SassHandler.cs
+++ b/libsassnet.Web/SassHandler.cs
@@ -38,7 +38,7 @@ namespace LibSassNet.Web
 
                 context.Response.ContentType = "text/css";
                 context.Response.Write(output);
-            } 
+            }
             else if (file.Name.EndsWith(".css", StringComparison.OrdinalIgnoreCase) && string.Equals(file.Extension, ".map", StringComparison.OrdinalIgnoreCase))
             {
                 string output = Compiler.CompileFile(path).SourceMap;

--- a/libsassnet.Web/SassTransform.cs
+++ b/libsassnet.Web/SassTransform.cs
@@ -18,8 +18,8 @@
 //OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //SOFTWARE.
 
-using System.Text;
 using System.Linq;
+using System.Text;
 using System.Web.Optimization;
 
 namespace LibSassNet.Web

--- a/libsassnet.Web/app.config
+++ b/libsassnet.Web/app.config
@@ -4,7 +4,15 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.5.2.14234" newVersion="1.5.2.14234" />
+        <bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Antlr3.Runtime" publicKeyToken="eb42632606e9261f" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.5.0.2" newVersion="3.5.0.2" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/libsassnet.Web/libsassnet.Web.x64.csproj
+++ b/libsassnet.Web/libsassnet.Web.x64.csproj
@@ -11,7 +11,6 @@
     <AssemblyName>libsassnet.Web</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <WebGreaseLibPath>..\packages\WebGrease.1.5.2\lib</WebGreaseLibPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
@@ -33,14 +32,15 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Antlr3.Runtime">
-      <HintPath>..\packages\Antlr.3.4.1.9004\lib\Antlr3.Runtime.dll</HintPath>
+      <HintPath>..\packages\Antlr.3.5.0.2\lib\Antlr3.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.5.0.4\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/libsassnet.Web/packages.config
+++ b/libsassnet.Web/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Antlr" version="3.4.1.9004" targetFramework="net40" />
+  <package id="Antlr" version="3.5.0.2" targetFramework="net40" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net40" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net40" />
-  <package id="Newtonsoft.Json" version="5.0.4" targetFramework="net40" />
-  <package id="WebGrease" version="1.5.2" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net40" />
+  <package id="WebGrease" version="1.6.0" targetFramework="net40" />
 </packages>

--- a/libsassnet/CompileFileResult.cs
+++ b/libsassnet/CompileFileResult.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace LibSassNet
+﻿namespace LibSassNet
 {
     public struct CompileFileResult
     {

--- a/libsassnet/ISassToScssConverter.cs
+++ b/libsassnet/ISassToScssConverter.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace LibSassNet
+﻿namespace LibSassNet
 {
     /// <summary>
     /// Converts SASS to SCSS

--- a/libsassnet/SassCompiler.cs
+++ b/libsassnet/SassCompiler.cs
@@ -69,7 +69,7 @@ namespace LibSassNet
             return context.OutputString;
         }
 
-        public CompileFileResult CompileFile(string inputPath, OutputStyle outputStyle = OutputStyle.Nested,  string sourceMapPath = null, bool includeSourceComments = true, int precision = 5, IEnumerable<string> additionalIncludePaths = null)
+        public CompileFileResult CompileFile(string inputPath, OutputStyle outputStyle = OutputStyle.Nested, string sourceMapPath = null, bool includeSourceComments = true, int precision = 5, IEnumerable<string> additionalIncludePaths = null)
         {
             if (outputStyle != OutputStyle.Nested && outputStyle != OutputStyle.Compressed)
             {

--- a/libsassnet/SassToScssConverter.cs
+++ b/libsassnet/SassToScssConverter.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace LibSassNet
+﻿namespace LibSassNet
 {
     public class SassToScssConverter : ISassToScssConverter
     {


### PR DESCRIPTION
* Addresses #13.
* Adds CompileAsManaged:false for all native
  source files.
  * Based on http://bit.ly/18eE4ZV.
  * This is required for three source files in<br/>
    LibSass, in v3, which are using C++11<br/>
    headers such as <atomic> which conflict<br/>
    with CLR. The solution is to turn off /clr<br/>
    flag on those source files. Since v3.2 will<br/>
    be using more C++11 features, I have disabled<br/>
    /clr flag on all native source files.<br/>
    Related: http://stackoverflow.com/q/15821942.

* Web: Updates Nuget packages.

* Code: Sorts and removes unused usings. 
  * Minor document formattings.

* CI: Adds AppVeyor.yml.

* README: Adds CI badge to readme.

@darrenkopp, you can see the passing build from my fork: https://ci.appveyor.com/project/am11/libsass-net. In order to configure your account, just logon with GitHub credentials on AppVeyor (https://ci.appveyor.com/login), add libsass-net in projects and run. All the future PRs will show build status.