### PR TITLE
Update libsass to v3.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libsass/native"]
 	path = libsass/native
-	url = https://github.com/hcatlin/libsass
+	url = git@github.com:sass/libsass.git

--- a/libsass/LibSass.vcxproj
+++ b/libsass/LibSass.vcxproj
@@ -27,99 +27,48 @@
     <ClCompile Include="native\cencode.c">
       <CompileAsManaged>false</CompileAsManaged>
     </ClCompile>
-    <ClCompile Include="native\constants.cpp">
-      <CompileAsManaged>false</CompileAsManaged>
-    </ClCompile>
+    <ClCompile Include="native\constants.cpp" />
     <ClCompile Include="native\context.cpp">
       <CompileAsManaged>false</CompileAsManaged>
     </ClCompile>
-    <ClCompile Include="native\contextualize.cpp">
-      <CompileAsManaged>false</CompileAsManaged>
-    </ClCompile>
-    <ClCompile Include="native\copy_c_str.cpp">
-      <CompileAsManaged>false</CompileAsManaged>
-    </ClCompile>
-    <ClCompile Include="native\error_handling.cpp">
-      <CompileAsManaged>false</CompileAsManaged>
-    </ClCompile>
-    <ClCompile Include="native\eval.cpp">
-      <CompileAsManaged>false</CompileAsManaged>
-    </ClCompile>
-    <ClCompile Include="native\expand.cpp">
-      <CompileAsManaged>false</CompileAsManaged>
-    </ClCompile>
-    <ClCompile Include="native\extend.cpp">
-      <CompileAsManaged>false</CompileAsManaged>
-    </ClCompile>
-    <ClCompile Include="native\file.cpp">
-      <CompileAsManaged>false</CompileAsManaged>
-    </ClCompile>
+    <ClCompile Include="native\contextualize.cpp" />
+    <ClCompile Include="native\contextualize_eval.cpp" />
+    <ClCompile Include="native\error_handling.cpp" />
+    <ClCompile Include="native\eval.cpp" />
+    <ClCompile Include="native\expand.cpp" />
+    <ClCompile Include="native\cssize.cpp" />
+    <ClCompile Include="native\listize.cpp" />
+    <ClCompile Include="native\extend.cpp" />
+    <ClCompile Include="native\file.cpp" />
     <ClCompile Include="native\functions.cpp">
       <CompileAsManaged>false</CompileAsManaged>
     </ClCompile>
-    <ClCompile Include="native\inspect.cpp">
-      <CompileAsManaged>false</CompileAsManaged>
+    <ClCompile Include="native\inspect.cpp" />
+    <ClCompile Include="native\json.cpp" >
+     <CompileAsManaged>false</CompileAsManaged>
     </ClCompile>
-    <ClCompile Include="native\json.cpp">
-      <CompileAsManaged>false</CompileAsManaged>
-    </ClCompile>
-    <ClCompile Include="native\node.cpp">
-      <CompileAsManaged>false</CompileAsManaged>
-    </ClCompile>
-    <ClCompile Include="native\output_compressed.cpp">
-      <CompileAsManaged>false</CompileAsManaged>
-    </ClCompile>
-    <ClCompile Include="native\output_nested.cpp">
-      <CompileAsManaged>false</CompileAsManaged>
-    </ClCompile>
-    <ClCompile Include="native\parser.cpp">
-      <CompileAsManaged>false</CompileAsManaged>
-    </ClCompile>
-    <ClCompile Include="native\prelexer.cpp">
-      <CompileAsManaged>false</CompileAsManaged>
-    </ClCompile>
-    <ClCompile Include="native\remove_placeholders.cpp">
-      <CompileAsManaged>false</CompileAsManaged>
-    </ClCompile>
-    <ClCompile Include="native\sass.cpp">
-      <CompileAsManaged>false</CompileAsManaged>
-    </ClCompile>
-    <ClCompile Include="native\sass2scss.cpp">
-      <CompileAsManaged>false</CompileAsManaged>
-    </ClCompile>
-    <ClCompile Include="native\sass_interface.cpp">
-      <CompileAsManaged>false</CompileAsManaged>
-    </ClCompile>
-    <ClCompile Include="native\sass_context.cpp">
-      <CompileAsManaged>false</CompileAsManaged>
-    </ClCompile>
-    <ClCompile Include="native\sass_functions.cpp">
-      <CompileAsManaged>false</CompileAsManaged>
-    </ClCompile>
-    <ClCompile Include="native\sass_values.cpp">
-      <CompileAsManaged>false</CompileAsManaged>
-    </ClCompile>
-    <ClCompile Include="native\sass_util.cpp">
-      <CompileAsManaged>false</CompileAsManaged>
-    </ClCompile>
-    <ClCompile Include="native\source_map.cpp">
-      <CompileAsManaged>false</CompileAsManaged>
-    </ClCompile>
-    <ClCompile Include="native\to_c.cpp">
-      <CompileAsManaged>false</CompileAsManaged>
-    </ClCompile>
-    <ClCompile Include="native\to_string.cpp">
-      <CompileAsManaged>false</CompileAsManaged>
-    </ClCompile>
-    <ClCompile Include="native\units.cpp">
-      <CompileAsManaged>false</CompileAsManaged>
-    </ClCompile>
-    <ClCompile Include="native\utf8_string.cpp">
-      <CompileAsManaged>false</CompileAsManaged>
-    </ClCompile>
-    <ClCompile Include="native\util.cpp">
-      <CompileAsManaged>false</CompileAsManaged>
-    </ClCompile>
+    <ClCompile Include="native\node.cpp" />
+    <ClCompile Include="native\emitter.cpp" />
+    <ClCompile Include="native\output.cpp" />
+    <ClCompile Include="native\parser.cpp" />
+    <ClCompile Include="native\plugins.cpp" />
+    <ClCompile Include="native\position.cpp" />
+    <ClCompile Include="native\lexer.cpp" />
+    <ClCompile Include="native\prelexer.cpp" />
+    <ClCompile Include="native\remove_placeholders.cpp" />
+    <ClCompile Include="native\sass.cpp" />
+    <ClCompile Include="native\sass2scss.cpp" />
+    <ClCompile Include="native\sass_interface.cpp" />
+    <ClCompile Include="native\sass_context.cpp" />
+    <ClCompile Include="native\sass_functions.cpp" />
+    <ClCompile Include="native\sass_values.cpp" />
+    <ClCompile Include="native\sass_util.cpp" />
+    <ClCompile Include="native\source_map.cpp" />
+    <ClCompile Include="native\to_c.cpp" />
+    <ClCompile Include="native\to_string.cpp" />
+    <ClCompile Include="native\units.cpp" />
+    <ClCompile Include="native\utf8_string.cpp" />
+    <ClCompile Include="native\util.cpp" />
     <ClCompile Include="SassInterface.cpp" />
     <ClCompile Include="StringToANSI.cpp" />
   </ItemGroup>
@@ -138,12 +87,14 @@
     <ClInclude Include="native\constants.hpp" />
     <ClInclude Include="native\context.hpp" />
     <ClInclude Include="native\contextualize.hpp" />
-    <ClInclude Include="native\copy_c_str.hpp" />
+    <ClInclude Include="native\contextualize_eval.hpp" />
     <ClInclude Include="native\debug.hpp" />
     <ClInclude Include="native\environment.hpp" />
     <ClInclude Include="native\error_handling.hpp" />
     <ClInclude Include="native\eval.hpp" />
     <ClInclude Include="native\expand.hpp" />
+    <ClInclude Include="native\cssize.hpp" />
+    <ClInclude Include="native\listize.hpp" />
     <ClInclude Include="native\extend.hpp" />
     <ClInclude Include="native\file.hpp" />
     <ClInclude Include="native\functions.hpp" />
@@ -154,11 +105,13 @@
     <ClInclude Include="native\memory_manager.hpp" />
     <ClInclude Include="native\node.hpp" />
     <ClInclude Include="native\operation.hpp" />
-    <ClInclude Include="native\output_compressed.hpp" />
-    <ClInclude Include="native\output_nested.hpp" />
+    <ClInclude Include="native\emitter.hpp" />
+    <ClInclude Include="native\output.hpp" />
     <ClInclude Include="native\parser.hpp" />
+    <ClInclude Include="native\plugins.hpp" />
     <ClInclude Include="native\paths.hpp" />
     <ClInclude Include="native\position.hpp" />
+    <ClInclude Include="native\lexer.hpp" />
     <ClInclude Include="native\prelexer.hpp" />
     <ClInclude Include="native\remove_placeholders.hpp" />
     <ClInclude Include="native\sass.h" />
@@ -194,7 +147,7 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v120</PlatformToolset>
-    <CharacterSet>NotSet</CharacterSet>
+    <CharacterSet>Unicode</CharacterSet>
     <CLRSupport>true</CLRSupport>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
@@ -209,7 +162,7 @@
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v120</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>NotSet</CharacterSet>
+    <CharacterSet>Unicode</CharacterSet>
     <CLRSupport>true</CLRSupport>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">

--- a/libsass/SassInterface.cpp
+++ b/libsass/SassInterface.cpp
@@ -40,7 +40,6 @@ namespace LibSassNet
 				ctx -> options.output_style = sassContext -> Options -> OutputStyle;
 				ctx -> options.source_comments = sassContext -> Options -> IncludeSourceComments;
 				ctx -> options.include_paths = MarshalString(sassContext -> Options -> IncludePaths);
-				ctx -> options.image_path = MarshalString(sassContext -> Options -> ImagePath);
 				ctx -> options.precision = sassContext -> Options -> Precision;
 			}
 
@@ -66,7 +65,6 @@ namespace LibSassNet
 		{
 			// Free resources
 			FreeString(ctx -> options.include_paths);
-			FreeString(ctx -> options.image_path);
 			FreeConstString(ctx -> source_string);
 			sass_free_context(ctx);
 		}
@@ -84,7 +82,6 @@ namespace LibSassNet
 				ctx -> options.output_style = sassFileContext -> Options -> OutputStyle;
 				ctx -> options.source_comments = sassFileContext -> Options -> IncludeSourceComments;
 				ctx -> options.include_paths = MarshalString(sassFileContext -> Options -> IncludePaths);
-				ctx -> options.image_path = MarshalString(sassFileContext -> Options -> ImagePath);
 				ctx -> options.source_map_file = MarshalString(sassFileContext -> OutputSourceMapFile);
 				ctx -> options.precision = sassFileContext -> Options -> Precision;
 			}
@@ -112,7 +109,6 @@ namespace LibSassNet
 		{
 			// Free resources
 			FreeString(ctx -> options.include_paths);
-			FreeString(ctx -> options.image_path);
 			FreeString(ctx -> input_path);
 			sass_free_file_context(ctx);
 		}

--- a/libsass/SassOptions.hpp
+++ b/libsass/SassOptions.hpp
@@ -31,7 +31,6 @@ namespace LibSassNet
 			property bool IncludeSourceComments;
 			property int Precision;
 			property String^ IncludePaths;
-			property String^ ImagePath;
 	};
 
 	public ref class SassContext

--- a/libsassnet.Web/libsassnet.Web.nuspec
+++ b/libsassnet.Web/libsassnet.Web.nuspec
@@ -2,7 +2,7 @@
 <package>
 	<metadata>
 		<id>$id$</id>
-		<version>1.9</version>
+		<version>2.0</version>
 		<authors>Darren Kopp</authors>
     <owners>Darren Kopp</owners>
     <licenseUrl>https://github.com/darrenkopp/libsass-net/blob/master/LICENSE</licenseUrl>
@@ -15,7 +15,7 @@
 		<tags>SASS SCSS CSS libsass System.Web.Optimization Microsoft.AspNet.Web.Optimization</tags>
 		<dependencies>
       <dependency id="Microsoft.AspNet.Web.Optimization" />
-			<dependency id="libsassnet" />
+			<dependency id="libsassnet" version="3.2.0.0" />
 		</dependencies>
 	</metadata>
   <files>

--- a/libsassnet.Web/libsassnet.Web.x64.nuspec
+++ b/libsassnet.Web/libsassnet.Web.x64.nuspec
@@ -2,7 +2,7 @@
 <package>
 	<metadata>
 		<id>$id$.x64</id>
-		<version>1.9</version>
+		<version>2.0</version>
 		<authors>Darren Kopp</authors>
 		<owners>Darren Kopp</owners>
 		<licenseUrl>https://github.com/darrenkopp/libsass-net/blob/master/LICENSE</licenseUrl>
@@ -15,7 +15,7 @@
 		<tags>SASS SCSS CSS libsass x64 System.Web.Optimization Microsoft.AspNet.Web.Optimization</tags>
 		<dependencies>
 			<dependency id="Microsoft.AspNet.Web.Optimization" />
-			<dependency id="libsassnet.x64" />
+			<dependency id="libsassnet.x64" version="3.2.0.0" />
 		</dependencies>
 	</metadata>
 	<files>

--- a/libsassnet/SassCompiler.cs
+++ b/libsassnet/SassCompiler.cs
@@ -54,7 +54,6 @@ namespace LibSassNet
                     OutputStyle = (int)outputStyle,
                     IncludeSourceComments = includeSourceComments,
                     IncludePaths = includePaths != null ? String.Join(";", includePaths) : String.Empty,
-                    ImagePath = string.Empty,
                     Precision = precision
                 }
             };
@@ -92,7 +91,6 @@ namespace LibSassNet
                     OutputStyle = (int)outputStyle,
                     IncludeSourceComments = includeSourceComments,
                     IncludePaths = String.Join(";", includePaths),
-                    ImagePath = string.Empty,
                     Precision = precision
                 },
                 OutputSourceMapFile = sourceMapPath

--- a/libsassnet/libsassnet.nuspec
+++ b/libsassnet/libsassnet.nuspec
@@ -2,7 +2,7 @@
 <package>
 	<metadata>
 		<id>$id$</id>
-		<version>3.1.0.0</version>
+		<version>3.2.0.0</version>
 		<authors>Darren Kopp</authors>
     <owners>Darren Kopp</owners>
 		<licenseUrl>https://github.com/darrenkopp/libsass-net/blob/master/LICENSE</licenseUrl>

--- a/libsassnet/libsassnet.x64.nuspec
+++ b/libsassnet/libsassnet.x64.nuspec
@@ -2,7 +2,7 @@
 <package>
 	<metadata>
 		<id>$id$.x64</id>
-		<version>3.1.0.0</version>
+		<version>3.2.0.0</version>
 		<authors>Darren Kopp</authors>
 		<owners>Darren Kopp</owners>
 		<licenseUrl>https://github.com/darrenkopp/libsass-net/blob/master/LICENSE</licenseUrl>


### PR DESCRIPTION
  * updated libsass to last version
  * removed ImagePath parameter from SassOptions as it was removed in libsass 3.2 
    * see https://github.com/sass/libsass/releases/tag/3.2.0-beta.1

@darrenkopp also this fixes random exceptions thrown from `sass_compile_file` #16 