### PR TITLE
context.Request.Path does not work for applications at the root of a website

### DIFF
--- a/libsassnet.Web/SassHandler.cs
+++ b/libsassnet.Web/SassHandler.cs
@@ -30,7 +30,7 @@ namespace LibSassNet.Web
 
         public void ProcessRequest(HttpContext context)
         {
-            string path = context.Server.MapPath(String.Format("~{0}", context.Request.Path));
+            string path = context.Server.MapPath(context.Request.AppRelativeCurrentExecutionFilePath);
             var file = new FileInfo(path);
             if (!file.Name.StartsWith("_") && string.Equals(file.Extension, ".scss", StringComparison.OrdinalIgnoreCase))
             {


### PR DESCRIPTION
If AppRelativeCurrentExecutionFilePath is used it works in any constellation