### PR TITLE
Code: Sends copy of string to upstream

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,3 +11,7 @@ before_build:
 build:
   verbosity: minimal
   project: libsass-net.sln
+
+on_success:
+  - 7z a libsass-net.zip .
+  - ps: Push-AppveyorArtifact libsass-net.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,7 @@
+platform:
+  - Win32
+  - x64
+
 configuration:
   - Debug
   - Release

--- a/libsass/SassInterface.cpp
+++ b/libsass/SassInterface.cpp
@@ -18,14 +18,9 @@
 //OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //SOFTWARE.
 
-#include <exception>
-#include "native\sass_interface.h"
 #include "native\sass2scss.h"
 #include "StringToANSI.hpp"
 #include "SassInterface.hpp"
-#include "native\sass_context.h"
-
-using namespace std;
 
 namespace LibSassNet
 {

--- a/libsass/SassInterface.cpp
+++ b/libsass/SassInterface.cpp
@@ -33,6 +33,7 @@ namespace LibSassNet
     {
         char* includePaths = MarshalString(sassContext->Options->IncludePaths);
         char* sourceString = MarshalString(sassContext->SourceString);
+        char* lineFeed = MarshalString(sassContext->Options->LineFeed);
         struct Sass_Data_Context* ctx;
 
         try
@@ -45,6 +46,7 @@ namespace LibSassNet
             sass_option_set_output_style(options, GetOutputStyle(sassContext->Options->OutputStyle));
             sass_option_set_source_comments(options, sassContext->Options->IncludeSourceComments);
             sass_option_set_precision(options, sassContext->Options->Precision);
+            sass_option_set_linefeed(options, lineFeed);
             sass_option_set_include_path(options, includePaths);
             sass_option_set_omit_source_map_url(options, true);
 
@@ -88,8 +90,9 @@ namespace LibSassNet
         char* includePaths = MarshalString(sassFileContext->Options->IncludePaths);
         char* mapFile = MarshalString(sassFileContext->OutputSourceMapFile);
         char* inputPath = MarshalString(sassFileContext->InputPath);
-
+        char* lineFeed = MarshalString(sassFileContext->Options->LineFeed);
         struct Sass_File_Context* ctx;
+
         try
         {
             ctx = sass_make_file_context(inputPath);
@@ -101,6 +104,7 @@ namespace LibSassNet
             sass_option_set_output_style(options, GetOutputStyle(sassFileContext->Options->OutputStyle));
             sass_option_set_source_comments(options, sassFileContext->Options->IncludeSourceComments);
             sass_option_set_precision(options, sassFileContext->Options->Precision);
+            sass_option_set_linefeed(options, lineFeed);
             sass_option_set_include_path(options, includePaths);
             sass_option_set_omit_source_map_url(options, String::IsNullOrEmpty(sassFileContext->OutputSourceMapFile));
             sass_option_set_source_map_file(options, mapFile);

--- a/libsass/SassInterface.cpp
+++ b/libsass/SassInterface.cpp
@@ -52,7 +52,7 @@ namespace LibSassNet
 
             sass_compile_data_context(ctx);
 
-            sassContext->ErrorStatus = sass_context_get_error_status(ctx_out);
+            sassContext->ErrorStatus = !!sass_context_get_error_status(ctx_out);
             sassContext->ErrorMessage = gcnew String(sass_context_get_error_message(ctx_out));
             sassContext->OutputString = gcnew String(sass_context_get_output_string(ctx_out));
 
@@ -111,7 +111,7 @@ namespace LibSassNet
 
             sass_compile_file_context(ctx);
 
-            sassFileContext->ErrorStatus = sass_context_get_error_status(ctx_out);
+            sassFileContext->ErrorStatus = !!sass_context_get_error_status(ctx_out);
             sassFileContext->ErrorMessage = gcnew String(sass_context_get_error_message(ctx_out));
             sassFileContext->OutputString = gcnew String(sass_context_get_output_string(ctx_out));
             sassFileContext->OutputSourceMap = gcnew String(sass_context_get_source_map_string(ctx_out));

--- a/libsass/SassInterface.cpp
+++ b/libsass/SassInterface.cpp
@@ -67,8 +67,6 @@ namespace LibSassNet
         finally
         {
             // Free resources
-            FreeString(includePaths);
-            FreeString(sourceString);
             sass_delete_data_context(ctx);
         }
     }
@@ -127,9 +125,6 @@ namespace LibSassNet
         finally
         {
             // Free resources
-            FreeString(includePaths);
-            FreeString(inputPath);
-            FreeString(mapFile);
             sass_delete_file_context(ctx);
         }
     }
@@ -156,6 +151,7 @@ namespace LibSassNet
         }
         finally
         {
+            // Upstream will not free the memory in case of sass2scss
             FreeString(sourceText);
         }
     }

--- a/libsass/SassInterface.cpp
+++ b/libsass/SassInterface.cpp
@@ -48,7 +48,7 @@ namespace LibSassNet
             sass_option_set_precision(options, sassContext->Options->Precision);
             sass_option_set_linefeed(options, lineFeed);
             sass_option_set_include_path(options, includePaths);
-            sass_option_set_omit_source_map_url(options, true);
+            sass_option_set_omit_source_map_url(options, sassContext->Options->OmitSourceMappingUrl);
 
             sass_compile_data_context(ctx);
 
@@ -106,7 +106,7 @@ namespace LibSassNet
             sass_option_set_precision(options, sassFileContext->Options->Precision);
             sass_option_set_linefeed(options, lineFeed);
             sass_option_set_include_path(options, includePaths);
-            sass_option_set_omit_source_map_url(options, String::IsNullOrEmpty(sassFileContext->OutputSourceMapFile));
+            sass_option_set_omit_source_map_url(options, sassFileContext->Options->OmitSourceMappingUrl);
             sass_option_set_source_map_file(options, mapFile);
 
             sass_compile_file_context(ctx);

--- a/libsass/SassInterface.hpp
+++ b/libsass/SassInterface.hpp
@@ -19,6 +19,7 @@
 //SOFTWARE.
 
 #include "ISassInterface.hpp"
+#include "native\sass_context.h"
 
 namespace LibSassNet
 {

--- a/libsass/SassOptions.hpp
+++ b/libsass/SassOptions.hpp
@@ -31,6 +31,7 @@ namespace LibSassNet
 			property bool IncludeSourceComments;
 			property int Precision;
 			property String^ IncludePaths;
+			property String^ LineFeed;
 	};
 
 	public ref class SassContext

--- a/libsass/SassOptions.hpp
+++ b/libsass/SassOptions.hpp
@@ -29,6 +29,7 @@ namespace LibSassNet
 		public:
 			property int OutputStyle;
 			property bool IncludeSourceComments;
+			property bool OmitSourceMappingUrl;
 			property int Precision;
 			property String^ IncludePaths;
 			property String^ LineFeed;

--- a/libsass/StringToANSI.cpp
+++ b/libsass/StringToANSI.cpp
@@ -19,6 +19,7 @@
 //SOFTWARE.
 
 #using <System.dll>
+#include <string>
 #include "StringToANSI.hpp"
 
 using namespace System;
@@ -27,8 +28,18 @@ using namespace System::Runtime::InteropServices;
 namespace LibSassNet
 {
 	char* MarshalString(String^ s)
-	{
-        return (char*) ((Marshal::StringToCoTaskMemAnsi(s)).ToPointer());
+    {
+        if (!s) {
+            return nullptr;
+        }
+
+        char* original_str = (char*)(Marshal::StringToCoTaskMemAnsi(s)).ToPointer();
+        char* target_str = (char*)malloc(strlen(original_str) + 1);
+        strcpy(target_str, original_str);
+
+        FreeString(original_str);
+
+        return target_str;
 	}
 
 	void FreeString(const char* p)

--- a/libsassnet/SassCompiler.cs
+++ b/libsassnet/SassCompiler.cs
@@ -31,6 +31,8 @@ namespace LibSassNet
 
         public string OutputLineFeed { get; set; }
 
+        public bool OmitSourceMappingUrl { get; set; }
+
         public SassCompiler()
         {
             _sassInterface = new SassInterface();
@@ -53,7 +55,8 @@ namespace LibSassNet
                     IncludeSourceComments = includeSourceComments,
                     IncludePaths = includePaths != null ? String.Join(";", includePaths) : String.Empty,
                     Precision = precision,
-                    LineFeed = OutputLineFeed ?? (OutputLineFeed = "\r\n")
+                    LineFeed = OutputLineFeed ?? (OutputLineFeed = "\r\n"),
+                    OmitSourceMappingUrl = OmitSourceMappingUrl
                 }
             };
 
@@ -87,7 +90,8 @@ namespace LibSassNet
                     IncludeSourceComments = includeSourceComments,
                     IncludePaths = String.Join(";", includePaths),
                     Precision = precision,
-                    LineFeed = OutputLineFeed ?? (OutputLineFeed = "\r\n")
+                    LineFeed = OutputLineFeed ?? (OutputLineFeed = "\r\n"),
+                    OmitSourceMappingUrl = OmitSourceMappingUrl
                 },
                 OutputSourceMapFile = sourceMapPath
             };

--- a/libsassnet/SassCompiler.cs
+++ b/libsassnet/SassCompiler.cs
@@ -29,6 +29,8 @@ namespace LibSassNet
     {
         private readonly ISassInterface _sassInterface;
 
+        public string OutputLineFeed { get; set; }
+
         public SassCompiler()
         {
             _sassInterface = new SassInterface();
@@ -50,7 +52,8 @@ namespace LibSassNet
                     OutputStyle = (int)outputStyle,
                     IncludeSourceComments = includeSourceComments,
                     IncludePaths = includePaths != null ? String.Join(";", includePaths) : String.Empty,
-                    Precision = precision
+                    Precision = precision,
+                    LineFeed = OutputLineFeed ?? (OutputLineFeed = "\r\n")
                 }
             };
 
@@ -83,7 +86,8 @@ namespace LibSassNet
                     OutputStyle = (int)outputStyle,
                     IncludeSourceComments = includeSourceComments,
                     IncludePaths = String.Join(";", includePaths),
-                    Precision = precision
+                    Precision = precision,
+                    LineFeed = OutputLineFeed ?? (OutputLineFeed = "\r\n")
                 },
                 OutputSourceMapFile = sourceMapPath
             };


### PR DESCRIPTION
##### a37f2f6 

Code: Sends copy of string to upstream.
LibSass changed this behavior recently that it will *own* the memory we
are passing to it. this delta makes changes to `MarshalString()` function
so it returns a copy of `char*` after freeing the converted `char*` from
`String^`.

Then it removes the unrequired `FreeString()` calls in `finally` block to
avoid "double-freeing".

Fixes #28

---
##### d09c4b5 

Options: Makes output linefeed adjustable. …  
* To make output readable in Notepad. :smile:
* LibSass new API exposes this option via `sass_option_set_linefeed`.
* This is a **non-breaking change** using additional property
  `OutputLineFeed` as opposed to altering the public `Compile`
  signature.
* The default is set to `\r\n` as opposed to libsass default `\r`.
* In user space, it will be adjustable as follow:

  ```c#
  var sassCompiler = new SassCompiler();
  sassCompiler.OutputLineFeed = "\r";
  Console.WriteLine(sassCompiler.CompileFile(@"C:\temp\blah.scss").CSS);
  ```

---
##### 9b4c3a3 

Code: Explicitly convert `int` to `bool`.
* Related discussion: sass/libsass#1490.
 
---

##### c65067a

 Options: Makes `sourceMappingURL` disableable.

---
#####  56c044c

Code: Purges unrequired (legacy) header.
* `sass_interface.h` is unused in favour of `sass_context.h`.
* Removes unnecessary `using namespace std;` (which is not ideal
  anyway).
* Removes `#include <exception>`.

---
##### 664d9e6 and 5c0ccec 
* CI: Store artifacts for each successful job.
* CI: Build for Win32 and x64 platforms.

It will zip the entire folder of libsass-net project and make the artifacts available under Artifacts tab for each job (`{Configuration, Platform}` pair) separately, as shown below:

![image](https://cloud.githubusercontent.com/assets/3840695/9504085/29502f0e-4c43-11e5-988b-2deed58635a1.png)
