### PR TITLE
 Web: Updates and fixes dependencies

### DIFF
--- a/libsassnet.Tests/packages.config
+++ b/libsassnet.Tests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.1.0-beta2-build2981" targetFramework="net451" />
+  <package id="xunit" version="2.1.0-beta4-build3109" targetFramework="net451" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net451" />
-  <package id="xunit.assert" version="2.1.0-beta2-build2981" targetFramework="net451" />
-  <package id="xunit.core" version="2.1.0-beta2-build2981" targetFramework="net451" />
-  <package id="xunit.extensibility.core" version="2.1.0-beta2-build2981" targetFramework="net451" />
-  <package id="xunit.runner.visualstudio" version="2.1.0-beta2-build1055" targetFramework="net451" />
+  <package id="xunit.assert" version="2.1.0-beta4-build3109" targetFramework="net451" />
+  <package id="xunit.core" version="2.1.0-beta4-build3109" targetFramework="net451" />
+  <package id="xunit.extensibility.core" version="2.1.0-beta4-build3109" targetFramework="net451" />
+  <package id="xunit.runner.visualstudio" version="2.1.0-beta4-build1109" targetFramework="net451" />
 </packages>

--- a/libsassnet.Web/libsassnet.Web.csproj
+++ b/libsassnet.Web/libsassnet.Web.csproj
@@ -11,7 +11,6 @@
     <AssemblyName>libsassnet.Web</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <WebGreaseLibPath>..\packages\WebGrease.1.5.2\lib</WebGreaseLibPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -32,14 +31,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Antlr3.Runtime">
-      <HintPath>..\packages\Antlr.3.4.1.9004\lib\Antlr3.Runtime.dll</HintPath>
+      <HintPath>..\packages\Antlr.3.5.0.2\lib\Antlr3.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.5.0.4\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -49,7 +45,7 @@
       <HintPath>..\packages\Microsoft.AspNet.Web.Optimization.1.1.3\lib\net40\System.Web.Optimization.dll</HintPath>
     </Reference>
     <Reference Include="WebGrease">
-      <HintPath>..\packages\WebGrease.1.5.2\lib\WebGrease.dll</HintPath>
+      <HintPath>..\packages\WebGrease.1.6.0\lib\WebGrease.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/libsassnet.Web/libsassnet.Web.x64.csproj
+++ b/libsassnet.Web/libsassnet.Web.x64.csproj
@@ -38,10 +38,6 @@
       <Private>True</Private>
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net40\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
@@ -50,7 +46,7 @@
       <HintPath>..\packages\Microsoft.AspNet.Web.Optimization.1.1.3\lib\net40\System.Web.Optimization.dll</HintPath>
     </Reference>
     <Reference Include="WebGrease">
-      <HintPath>..\packages\WebGrease.1.5.2\lib\WebGrease.dll</HintPath>
+      <HintPath>..\packages\WebGrease.1.6.0\lib\WebGrease.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/libsassnet.Web/packages.config
+++ b/libsassnet.Web/packages.config
@@ -3,6 +3,5 @@
   <package id="Antlr" version="3.5.0.2" targetFramework="net40" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net40" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net40" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net40" />
   <package id="WebGrease" version="1.6.0" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
* `Newtonsoft.Json` was not required.
* `xunit` and `Antlr` versions were old.